### PR TITLE
fix "npm run build" command error

### DIFF
--- a/app/Commands/NuxtBuild.js
+++ b/app/Commands/NuxtBuild.js
@@ -38,7 +38,9 @@ class NuxtBuild extends Command {
     config.dev = false
     this.nuxt = new Nuxt(config)
     this.info('Building nuxt.js application...')
-    yield this.nuxt.build()
+    this.nuxt.then((nuxt) => {
+      nuxt.build()
+    })
   }
 
 }


### PR DESCRIPTION
I get error when trying to  run "npm run build" command:
TypeError: this.nuxt.build is not a function